### PR TITLE
[chihiro]お気に入り商品一覧を返す

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,7 +64,7 @@ Sample code for calling some endpoints after running server
 $ curl -X POST 'http://127.0.0.1:9000/register' -d '{"name": "momom", "password": "password"}'  -H 'Content-Type: application/json'
 # Login (get login token)
 # {"id":11,"name":"momom","token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxMSwiZXhwIjoxNjg0NTgxNjU3fQ.7YGvgOsKI1EIr8a9yw0Ny6GRmmUJjrAkjjypdpj74qw"}
-$ curl -i -X POST 'http://127.0.0.1:9000/login' -d '{"user_id": 1, "password": "password"}'  -H 'Content-Type: application/json'
+$ curl -i -X POST 'http://127.0.0.1:9000/login' -d '{"user_id": 11, "password": "password"}'  -H 'Content-Type: application/json'
 # Add item
 # Please put image.jpg on backend folder to call this endpoint 
 # {"id":21}
@@ -100,7 +100,10 @@ curl -X POST 'http://127.0.0.1:9000/purchase/1' -H "Authorization: Bearer <ロ�
 curl -X GET 'http://127.0.0.1:9000/favorite' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>"
 
 # Add an item to a favorite folder
-curl -X POST 'http://127.0.0.1:9000/favorite' -d '{"item_id": 3, "folder_id": 2}' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>" -H 'Content-Type: application/json'
+curl -X POST 'http://127.0.0.1:9000/favorite' -d '{"item_id": 2, "folder_id": 1}' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>" -H 'Content-Type: application/json'
+
+# Get faborite items
+curl -X GET 'http://127.0.0.1:9000/favorite/1' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>"
 ```
 
 ###  Structure

--- a/backend/domain/item.go
+++ b/backend/domain/item.go
@@ -31,3 +31,8 @@ type FavoriteFolder struct {
 	FavoriteFolderID   int64
 	FavoriteFolderName string
 }
+
+type FavoriteItem struct {
+	ItemID   int32
+	FolderID   int32
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -99,6 +99,7 @@ func run(ctx context.Context) int {
 	l.POST("/balance", h.AddBalance)
 	l.GET("/favorite", h.GetFavoriteFolders)
 	l.POST("/favorite", h.AddItemToFavoriteFolder)
+	l.GET("/favorite/:folderID", h.GetFavoriteItems)
 
 	// Start server
 	go func() {


### PR DESCRIPTION
folderIDを指定すると、その中に入ったお気に入り商品一覧を返す機能を実装しました。
READMEにコマンド例が書いてあります。

GET(“/favorite/:folderID”)を送ると
[{"id":3,"name":"Cucumber","price":80,"category_name":"food"},{"id":2,"name":"Cabbage","price":100,"category_name":"food"}]
のように商品一覧を表示する際と同じ情報が返ってきます。
