### PR TITLE
[chihiro]重複した商品データを取得しないように修正

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -232,7 +232,7 @@ func (r *ItemDBRepository) AddItemToFavoriteFolder(ctx context.Context, itemID i
 }
 
 func (r *ItemDBRepository) GetFavoriteItems(ctx context.Context, folderID int64) ([]domain.FavoriteItem, error) {
-	rows, err := r.QueryContext(ctx, "SELECT * FROM favorite WHERE favorite_folder_id = ?", folderID)
+	rows, err := r.QueryContext(ctx, "SELECT DISTINCT * FROM favorite WHERE favorite_folder_id = ?", folderID)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
もしお気に入り商品のフォルダに全く同じデータが複数入っていた場合、お気に入り商品一覧を取得する際に結果が重複しないように修正しました