### PR TITLE
[chihiro]お気に入りフォルダの追加機能

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -107,6 +107,9 @@ curl -X GET 'http://127.0.0.1:9000/favorite/1' -H "Authorization: Bearer <ログ
 
 # Remove a favorite item
 curl -X POST 'http://127.0.0.1:9000/favorite/delete' -d '{"item_id": 4, "folder_id": 1}' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>" -H 'Content-Type: application/json'
+
+# Add a new favorite folder
+curl -X POST 'http://127.0.0.1:9000/favorite/new' -d '{"folder_name": "hobby"}' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>" -H 'Content-Type: application/json'
 ```
 
 ###  Structure

--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -61,7 +61,8 @@ type ItemRepository interface {
 	GetFolders(ctx context.Context, id int64) ([]domain.FavoriteFolder, error)
 	AddItemToFavoriteFolder(ctx context.Context, itemID int32, folderID int32) error
 	GetFavoriteItems(ctx context.Context, folderID int64) ([]domain.FavoriteItem, error)
-	RemoveFavoriteItem(tx context.Context, itemID int32, folderID int32) error
+	RemoveFavoriteItem(ctx context.Context, itemID int32, folderID int32) error
+	AddFavoriteFolder(ctx context.Context, userID int64, folderName string) error
 }
 
 type ItemDBRepository struct {
@@ -255,6 +256,13 @@ func (r *ItemDBRepository) GetFavoriteItems(ctx context.Context, folderID int64)
 
 func (r *ItemDBRepository) RemoveFavoriteItem(ctx context.Context, itemID int32, folderID int32) error {
 	if _, err := r.ExecContext(ctx, "DELETE FROM favorite WHERE item_id = ? and favorite_folder_id = ?", itemID, folderID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ItemDBRepository) AddFavoriteFolder(ctx context.Context, userID int64, folderName string) error {
+	if _, err := r.ExecContext(ctx, "INSERT INTO favoriteFolders (user_id, favorite_folder_name) VALUES (?, ?)", userID, folderName); err != nil {
 		return err
 	}
 	return nil

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -147,6 +147,10 @@ type removeFavoriteItemRequest struct {
 	FolderID int32 `json:"folder_id"`
 }
 
+type addFavoriteFolderRequest struct {
+	FolderName string `json:"folder_name" validate:"required`
+}
+
 func GetSecret() string {
 	if secret := os.Getenv("SECRET"); secret != "" {
 		return secret
@@ -773,6 +777,26 @@ func (h *Handler) RemoveFavoriteItem(c echo.Context) error {
 
 	if err := h.ItemRepo.RemoveFavoriteItem(ctx, req.ItemID, req.FolderID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "cannot delete the favorite item")
+	}	
+
+	return c.JSON(http.StatusOK, "successful")
+}
+
+func (h *Handler) AddNewFavoriteFolder(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := getUserID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, err)
+	}
+
+	req := new(addFavoriteFolderRequest)
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err)
+	}
+
+	if err := h.ItemRepo.AddFavoriteFolder(ctx, userID, req.FolderName); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "cannot add a favorite folder")
 	}	
 
 	return c.JSON(http.StatusOK, "successful")

--- a/backend/main.go
+++ b/backend/main.go
@@ -101,6 +101,7 @@ func run(ctx context.Context) int {
 	l.POST("/favorite", h.AddItemToFavoriteFolder)
 	l.GET("/favorite/:folderID", h.GetFavoriteItems)
 	l.POST("/favorite/delete", h.RemoveFavoriteItem)
+	l.POST("/favorite/new", h.AddNewFavoriteFolder)
 
 	// Start server
 	go func() {


### PR DESCRIPTION
POST("favorite/new")でjsonで{"folder_name": "hobby"}のようにデータを渡すと新しいお気に入りフォルダが作成されるような機能を実装しました。
```curl -X POST 'http://127.0.0.1:9000/favorite/new' -d '{"folder_name": "hobby"}' -H "Authorization: Bearer <ログイン時のレスポンスで返ってきたtokenの値を入れる>" -H 'Content-Type: application/json'```
を打って確認できます
